### PR TITLE
added setting that enables for on/off tags

### DIFF
--- a/misc/org.palladiosimulator.codeconventions/palladio-code-formatter.xml
+++ b/misc/org.palladiosimulator.codeconventions/palladio-code-formatter.xml
@@ -265,5 +265,6 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
 </profile>
 </profiles>


### PR DESCRIPTION
I suggest allowing on/off tags to enable custom formatting for stream expressions. Example (from JDK8 javadoc):

```java
// @formatter:off
int sum = widgets.stream()
                 .filter(b -> b.getColor() == RED)
                 .mapToInt(b -> b.getWeight())
                 .sum();                
// @formatter:on
```

Alternatively, it would also be possible to use _Line wrapping -> Never join already wrapped lines_. I am however not sure whether we want that.

If there is a better way of doing this (for example a setting that automatically formats these expressions in a good way), I am of course also fine with that.